### PR TITLE
Integrate FinBERT and improve reliability

### DIFF
--- a/bot_integration/mood_gate.py
+++ b/bot_integration/mood_gate.py
@@ -1,18 +1,30 @@
 import MySQLdb as mdb
 import os
+import threading
+
+_conn_local = threading.local()
+
+def _get_conn():
+    conn = getattr(_conn_local, "conn", None)
+    if conn is None or not conn.open:
+        _conn_local.conn = mdb.connect(
+            host=os.getenv("MYSQL_HOST", "db"),
+            user=os.getenv("MYSQL_USER", "root"),
+            passwd=os.getenv("MYSQL_PASSWORD", "root"),
+            db=os.getenv("MYSQL_DB", "trading"),
+            port=int(os.getenv("MYSQL_PORT", "3306")),
+            charset="utf8mb4",
+            autocommit=True,
+        )
+    return _conn_local.conn
 
 def get_latest_mood(symbol: str) -> float | None:
-    conn = mdb.connect(
-        host=os.getenv("MYSQL_HOST","db"),
-        user=os.getenv("MYSQL_USER","root"),
-        passwd=os.getenv("MYSQL_PASSWORD","root"),
-        db=os.getenv("MYSQL_DB","trading"),
-        port=int(os.getenv("MYSQL_PORT","3306")),
-        charset="utf8mb4",
-        autocommit=True,
-    )
+    conn = _get_conn()
     with conn.cursor() as cur:
-        cur.execute("SELECT mood_score FROM sentiment_agg WHERE symbol=%s ORDER BY ts DESC LIMIT 1", (symbol,))
+        cur.execute(
+            "SELECT mood_score FROM sentiment_agg WHERE symbol=%s ORDER BY ts DESC LIMIT 1",
+            (symbol,),
+        )
         row = cur.fetchone()
         return float(row[0]) if row else None
 

--- a/sentiment_service/fastapi_sentiment.py
+++ b/sentiment_service/fastapi_sentiment.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List
+from typing import List, Callable
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
@@ -12,22 +15,49 @@ class Item(BaseModel):
 def health():
     return {"ok": True}
 
-# TODO: Replace with FinBERT or another finance-tuned model.
-# Stub heuristic: + if contains bullish verbs, - if contains bearish verbs.
+############################################################
+# Sentiment model
+############################################################
+
 BULL = {"beat","beats","up","surge","guidance","buy","upgrade","breakout","bull"}
 BEAR = {"miss","misses","down","plunge","downgrade","sell","hack","bear"}
 
 def stub_sentiment(text: str) -> float:
+    """Fallback heuristic when FinBERT isn't available."""
     t = text.lower()
     p = sum(1 for w in BULL if w in t)
     n = sum(1 for w in BEAR if w in t)
-    score = np.tanh(0.7*(p-n))  # -1..1
+    score = np.tanh(0.7 * (p - n))  # -1..1
     return float(score)
+
+sentiment_fn: Callable[[str], float] = stub_sentiment
+
+try:  # pragma: no cover - heavy dependency; exercised in production
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification, pipeline
+
+    _tokenizer = AutoTokenizer.from_pretrained("ProsusAI/finbert")
+    _model = AutoModelForSequenceClassification.from_pretrained("ProsusAI/finbert")
+    _pipe = pipeline("sentiment-analysis", model=_model, tokenizer=_tokenizer)
+
+    def finbert_sentiment(text: str) -> float:
+        res = _pipe(text)[0]
+        label = res["label"].lower()
+        score = res["score"]
+        if label == "positive":
+            return float(score)
+        if label == "negative":
+            return float(-score)
+        return 0.0
+
+    sentiment_fn = finbert_sentiment
+    logger.info("FinBERT model loaded")
+except Exception as exc:  # pragma: no cover - exercised when model unavailable
+    logger.warning("FinBERT unavailable, using heuristic sentiment: %s", exc)
 
 def normalize(x: float) -> float:
     return float((x + 1.0) * 50.0)  # -> 0..100
 
 @app.post("/score")
 def score(item: Item):
-    raw = [stub_sentiment(t) for t in item.texts]
+    raw = [sentiment_fn(t) for t in item.texts]
     return {"scores": [normalize(x) for x in raw]}

--- a/sentiment_service/requirements.txt
+++ b/sentiment_service/requirements.txt
@@ -2,3 +2,6 @@ fastapi==0.115.0
 uvicorn==0.30.6
 numpy==2.0.1
 pydantic==2.8.2
+httpx==0.27.0
+transformers==4.43.4
+torch==2.3.0

--- a/workers/fusion.py
+++ b/workers/fusion.py
@@ -1,7 +1,11 @@
 import os
 import time
 import numpy as np
+import logging
 from utils import DB, now_utc, get_env_symbols, get_regime_adj, normalize_from_raw
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 FUSE_WINDOW_MIN = int(os.getenv('FUSE_WINDOW_MIN','120'))
 W_NEWS = float(os.getenv('SENT_W_NEWS','0.5'))
@@ -66,7 +70,7 @@ def loop():
             for sym in symbols:
                 fuse_symbol(db, sym)
         except Exception:
-            pass
+            logger.exception("fusion loop error")
         time.sleep(30)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Wire FinBERT into sentiment service with heuristic fallback and normalize scores
- Reuse MySQL connections via thread-local cache
- Log worker errors instead of silently passing
- Declare required HTTP and ML libraries for production use

## Testing
- `pip install httpx==0.27.0` *(fails: Could not find a version that satisfies the requirement)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689d3d5dfcbc8331ac3cce97fc4b4bc7