### PR TITLE
chore: expand .env settings

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,26 @@
+# Database configuration
+MYSQL_HOST=db
+MYSQL_PORT=3306
+MYSQL_USER=root
+MYSQL_PASSWORD=root
+MYSQL_DB=trading
+
+# Sentiment service
+SENTIMENT_URL=http://sentiment:8000/score
+
+# Metrics
+METRICS_PORT=9000
+
+# News worker settings
+NEWS_POLL_SEC=180
+NEWS_FEEDS=https://example.com/feed1,https://example.com/feed2
+NEWS_HASH_TTL_HOURS=168
+
+# Fusion worker settings
+FUSE_WINDOW_MIN=120
+ENTRY_BLOCK=30
+SIZE_UP=70
+REGIME_MIN=0.6
+
+# Stocktwits worker settings
+STOCKTWITS_POLL_SEC=120


### PR DESCRIPTION
## Summary
- add database, sentiment, metrics, news, fusion, and stocktwits defaults to `.env`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e53e2a4748331b785ed27ccab90f7