### PR TITLE
Install pkg-config for mysqlclient build

### DIFF
--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y build-essential default-libmysqlclient-dev curl \
+RUN apt-get update && apt-get install -y build-essential default-libmysqlclient-dev pkg-config curl \
     && pip install --no-cache-dir -r requirements.txt \
     && rm -rf /var/lib/apt/lists/*
 COPY utils.py worker_news.py worker_stocktwits.py fusion.py .


### PR DESCRIPTION
## Summary
- Ensure Docker image installs pkg-config so mysqlclient can be built successfully

## Testing
- `pytest`
- ⚠️ `docker compose build worker-crypto` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689e70c471708331af8f1d2166054a30